### PR TITLE
fix(rate-limiter): fixed rate limit window bug

### DIFF
--- a/src/providers/ratelimit-action.provider.ts
+++ b/src/providers/ratelimit-action.provider.ts
@@ -49,6 +49,7 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
       if (redisDS?.connector) {
         opts.store = new RedisStore.default({
           client: redisDS.connector._client,
+          expiry: (opts.windowMs ?? 60 * 1000) / 1000,
         });
       }
 


### PR DESCRIPTION
## Description

Fixed a bug where windowMs config provided was not working as expected.

As mentioned in the docs of [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) - "with non-default stores, you may need to configure this value twice, once here and once on the store. In some cases the units also differ (e.g. seconds vs miliseconds)", so applied the changes according to the store we have used - [rate-limit-redis](https://www.npmjs.com/package/rate-limit-redis).

Fixes - #9 , #19 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [X] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the style guide
