### PR TITLE
feat:added in memory support as demanded in issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![LoopBack](<https://github.com/strongloop/loopback-next/raw/master/docs/site/imgs/branding/Powered-by-LoopBack-Badge-(blue)-@2x.png>)](http://loopback.io/)
 
-A simple loopback-next extension for rate limiting in loopback applications. This extension uses [express-rate-limit](https://github.com/nfriedly/express-rate-limit) under the hood with redis used as store for rate limiting key storage using [rate-limit-redis](https://github.com/wyattjoh/rate-limit-redis)
+A simple loopback-next extension for rate limiting in loopback applications. This extension uses [express-rate-limit](https://github.com/nfriedly/express-rate-limit) under the hood with redis, memcache and mongodDB used as store for rate limiting key storage using [rate-limit-redis](https://github.com/wyattjoh/rate-limit-redis), [rate-limit-memcached](https://github.com/linyows/rate-limit-memcached) and [rate-limit-mongo](https://github.com/2do2go/rate-limit-mongo)
 
 ## Install
 
@@ -20,15 +20,38 @@ In order to use this component into your LoopBack application, please follow bel
 this.component(RateLimiterComponent);
 ```
 
-- Minimum configuration required for this component to work is the redis datasource name. Please provide it as below.
+- Minimum configuration required for this component to work is the datasource name. Please provide it as below.
+
+For redis datasource
 
 ```ts
 this.bind(RateLimitSecurityBindings.CONFIG).to({
   name: 'redis',
+  type:'RedisStore';
 });
 ```
 
-- By default, ratelimiter will be initialized with default options as mentioned [here](https://github.com/nfriedly/express-rate-limit#configuration-options). However, you can override any of the options using the Config Binding like below.
+For memcache datasource
+
+```ts
+this.bind(RateLimitSecurityBindings.CONFIG).to({
+  name: 'memcache',
+  type:'MemcachedStore';
+});
+```
+
+For mongoDB datasource
+
+```ts
+this.bind(RateLimitSecurityBindings.CONFIG).to({
+  name: 'mongo',
+  type:'MongoStore';
+  uri: 'mongodb://127.0.0.1:27017/test_db',
+  collectionName: 'expressRateRecords'
+});
+```
+
+- By default, ratelimiter will be initialized with default options as mentioned [here](https://github.com/nfriedly/express-rate-limit#configuration-options). However, you can override any of the options using the Config Binding. Below is an example of how to do it with the redis datasource, you can also do it with other two datasources similarly.
 
 ```ts
 const rateLimitKeyGen = (req: Request) => {
@@ -42,8 +65,10 @@ const rateLimitKeyGen = (req: Request) => {
 
 ......
 
+
 this.bind(RateLimitSecurityBindings.CONFIG).to({
   name: 'redis',
+  type: 'RedisStore',
   max: 60,
   keyGenerator: rateLimitKeyGen,
 });

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In order to use this component into your LoopBack application, please follow bel
 this.component(RateLimiterComponent);
 ```
 
-- Minimum configuration required for this component to work is the datasource name. Please provide it as below.
+- Minimum configuration required for this component is given below.
 
 For redis datasource
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,6 +885,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
     },
+    "@types/memcached": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.6.tgz",
+      "integrity": "sha512-7FTcKNkfzc7tfywZo0qtAbAnKTQoyDbCB4xQXXSVQqbXM0PQy0hRFPVymLoicBwaKLqDbL8thRGvF3wKRTnwvg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -902,9 +911,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
-      "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg==",
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "dev": true
     },
     "@types/on-finished": {
@@ -1396,6 +1405,11 @@
         "node-releases": "^1.1.71"
       }
     },
+    "bson": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1597,6 +1611,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "connection-parse": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+      "integrity": "sha1-GOcxiqsGppkmc3KxDFIm0locmmk="
     },
     "constant-case": {
       "version": "3.0.4",
@@ -2648,6 +2667,15 @@
         "type-fest": "^0.8.0"
       }
     },
+    "hashring": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+      "integrity": "sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=",
+      "requires": {
+        "connection-parse": "0.0.x",
+        "simple-lru-cache": "0.0.x"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -3100,6 +3128,14 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jackpot": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+      "integrity": "sha1-PP8GQoXL9m9OqyWTyQvOgWqCGEk=",
+      "requires": {
+        "retry": "0.6.0"
+      }
+    },
     "jake": {
       "version": "10.8.2",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
@@ -3487,6 +3523,21 @@
         "p-is-promise": "^2.1.0"
       }
     },
+    "memcached": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
+      "integrity": "sha1-aPhsz9hLz5PMJe1G1tf8DHUhydU=",
+      "requires": {
+        "hashring": "3.2.x",
+        "jackpot": ">=0.0.6"
+      }
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -3640,6 +3691,19 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "mongodb": {
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.9.tgz",
+      "integrity": "sha512-1nSCKgSunzn/CXwgOWgbPHUWOO5OfERcuOWISmqd610jn0s8BU9K4879iJVabqgpPPbA6hO7rG48eq+fGED3Mg==",
+      "requires": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.0.3",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
       }
     },
     "ms": {
@@ -4064,6 +4128,11 @@
         "yaml": "^1.10.0"
       }
     },
+    "optional-require": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -4282,6 +4351,11 @@
         }
       }
     },
+    "postgres": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-1.0.2.tgz",
+      "integrity": "sha512-zeLgt42KSUNgX/uvo+gbVxTAYwgSY6MIKuU/a8YWuObX4rtGuKrVWopvEAqIAPSO0FeHS1TsSKnqPjoufPy8NA=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4370,6 +4444,24 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "rate-limit-memcached": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rate-limit-memcached/-/rate-limit-memcached-0.6.0.tgz",
+      "integrity": "sha512-/qVmM6JqOosUPynxEVm0t7DEYv5k/HVybVyqjA07PahMg9CLhzC4llYRzJKPOiop8BQlS8tMh6DBksnAI+0T7w==",
+      "requires": {
+        "memcached": "^2.2.2"
+      }
+    },
+    "rate-limit-mongo": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-mongo/-/rate-limit-mongo-2.3.1.tgz",
+      "integrity": "sha512-sl0T3G6aB6hgawZldDlvDZ8vi2tIxbcpk/N1WdI4jsS1/FqdDF92jKeCQiE8Oq7kDSsU+jFT142GE6HfKWKrUw==",
+      "requires": {
+        "mongodb": ">= 3.3.4 < 4.0.0",
+        "twostep": "0.4.2",
+        "underscore": "1.12.1"
+      }
     },
     "rate-limit-redis": {
       "version": "2.1.0",
@@ -4533,6 +4625,11 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "retry": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+      "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -4566,6 +4663,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
     },
     "semver": {
       "version": "7.3.5",
@@ -4766,6 +4872,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
+    "simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
+    },
     "sinon": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
@@ -4886,6 +4997,15 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
       }
     },
     "spawn-wrap": {
@@ -5187,6 +5307,11 @@
         }
       }
     },
+    "twostep": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/twostep/-/twostep-0.4.2.tgz",
+      "integrity": "sha1-hLxQh6hxV00ev3vjB54D4SLUFbY="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5242,6 +5367,11 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4351,11 +4351,6 @@
         }
       }
     },
-    "postgres": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/postgres/-/postgres-1.0.2.tgz",
-      "integrity": "sha512-zeLgt42KSUNgX/uvo+gbVxTAYwgSY6MIKuU/a8YWuObX4rtGuKrVWopvEAqIAPSO0FeHS1TsSKnqPjoufPy8NA=="
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback4-ratelimiter",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback4-ratelimiter",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A rate limiting extension for loopback-next APIs",
   "keywords": [
     "loopback-extension",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "express-rate-limit": "^5.1.3",
     "loopback-connector-kv-redis": "^4.0.0",
     "memcached": "^2.2.2",
-    "postgres": "^1.0.2",
     "rate-limit-memcached": "^0.6.0",
     "rate-limit-mongo": "^2.3.1",
     "rate-limit-redis": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
     "@loopback/rest": "^9.3.0",
     "express-rate-limit": "^5.1.3",
     "loopback-connector-kv-redis": "^4.0.0",
+    "memcached": "^2.2.2",
+    "postgres": "^1.0.2",
+    "rate-limit-memcached": "^0.6.0",
+    "rate-limit-mongo": "^2.3.1",
     "rate-limit-redis": "^2.1.0"
   },
   "devDependencies": {
@@ -56,7 +60,8 @@
     "@loopback/eslint-config": "^10.2.0",
     "@loopback/testlab": "^3.4.0",
     "@types/express-rate-limit": "^5.0.0",
-    "@types/node": "^10.17.59",
+    "@types/memcached": "^2.2.6",
+    "@types/node": "^10.17.60",
     "@types/rate-limit-redis": "^1.7.1",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,13 +1,13 @@
 import {Binding, Component, ProviderMap} from '@loopback/core';
-
 import {RateLimitSecurityBindings} from './keys';
-import {RatelimitActionProvider, RateLimitMetadataProvider} from './providers';
+import {RatelimitActionProvider, RateLimitMetadataProvider,RatelimitDatasourceProvider} from './providers';
 
 export class RateLimiterComponent implements Component {
   constructor() {
     this.providers = {
       [RateLimitSecurityBindings.RATELIMIT_SECURITY_ACTION
         .key]: RatelimitActionProvider,
+      [RateLimitSecurityBindings.DATASOURCEPROVIDER.key] : RatelimitDatasourceProvider,
       [RateLimitSecurityBindings.METADATA.key]: RateLimitMetadataProvider,
     };
     this.bindings.push(

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,13 +1,18 @@
 import {Binding, Component, ProviderMap} from '@loopback/core';
 import {RateLimitSecurityBindings} from './keys';
-import {RatelimitActionProvider, RateLimitMetadataProvider,RatelimitDatasourceProvider} from './providers';
+import {
+  RatelimitActionProvider,
+  RateLimitMetadataProvider,
+  RatelimitDatasourceProvider,
+} from './providers';
 
 export class RateLimiterComponent implements Component {
   constructor() {
     this.providers = {
       [RateLimitSecurityBindings.RATELIMIT_SECURITY_ACTION
         .key]: RatelimitActionProvider,
-      [RateLimitSecurityBindings.DATASOURCEPROVIDER.key] : RatelimitDatasourceProvider,
+      [RateLimitSecurityBindings.DATASOURCEPROVIDER
+        .key]: RatelimitDatasourceProvider,
       [RateLimitSecurityBindings.METADATA.key]: RateLimitMetadataProvider,
     };
     this.bindings.push(

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,5 +1,5 @@
 import {BindingKey, MetadataAccessor} from '@loopback/core';
-
+import {Store} from 'express-rate-limit';
 import {RateLimitAction, RateLimitOptions, RateLimitMetadata} from './types';
 
 export namespace RateLimitSecurityBindings {
@@ -14,6 +14,13 @@ export namespace RateLimitSecurityBindings {
   export const CONFIG = BindingKey.create<RateLimitOptions | null>(
     'sf.security.ratelimit.config',
   );
+
+  export const DATASOURCEPROVIDER = BindingKey.create<Store | null>(
+    'sf.security.ratelimit.datasourceProvider',
+  );
+
+
+
 }
 
 export const RATELIMIT_METADATA_ACCESSOR = MetadataAccessor.create<

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -18,9 +18,6 @@ export namespace RateLimitSecurityBindings {
   export const DATASOURCEPROVIDER = BindingKey.create<Store | null>(
     'sf.security.ratelimit.datasourceProvider',
   );
-
-
-
 }
 
 export const RATELIMIT_METADATA_ACCESSOR = MetadataAccessor.create<

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,2 +1,3 @@
 export * from './ratelimit-action.provider';
 export * from './ratelimit-metadata.provider';
+export * from './ratelimit-datasource.provider';

--- a/src/providers/ratelimit-action.provider.ts
+++ b/src/providers/ratelimit-action.provider.ts
@@ -1,14 +1,20 @@
 import {CoreBindings, inject, Provider} from '@loopback/core';
-import {Getter, juggler} from '@loopback/repository';
+import {Getter} from '@loopback/repository';
 import {Request, Response, RestApplication, HttpErrors} from '@loopback/rest';
 import * as RateLimit from 'express-rate-limit';
-import * as RedisStore from 'rate-limit-redis';
-
 import {RateLimitSecurityBindings} from '../keys';
 import {RateLimitAction, RateLimitMetadata, RateLimitOptions} from '../types';
+import {RatelimitDatasourceProvider} from './ratelimit-datasource.provider';
+
+
+
+
 
 export class RatelimitActionProvider implements Provider<RateLimitAction> {
   constructor(
+
+    @inject(RateLimitSecurityBindings.DATASOURCEPROVIDER.key)
+    private datastore : RatelimitDatasourceProvider,
     @inject.getter(RateLimitSecurityBindings.METADATA)
     private readonly getMetadata: Getter<RateLimitMetadata>,
     @inject(CoreBindings.APPLICATION_INSTANCE)
@@ -17,6 +23,7 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
       optional: true,
     })
     private readonly config?: RateLimitOptions,
+
   ) {}
 
   value(): RateLimitAction {
@@ -30,13 +37,6 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
       return Promise.resolve();
     }
 
-    // For redis datasource
-    let redisDS: juggler.DataSource;
-    if (this.config) {
-      redisDS = (await this.application.get(
-        `datasources.${this.config.name}`,
-      )) as juggler.DataSource;
-    }
 
     // Perform rate limiting now
     const promise = new Promise<void>((resolve, reject) => {
@@ -46,11 +46,13 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
       // Create options based on global config and method level config
       const opts = Object.assign({}, this.config, operationMetadata);
 
-      if (redisDS?.connector) {
-        opts.store = new RedisStore.default({
-          client: redisDS.connector._client,
-        });
+
+      if (this.datastore) {
+      opts.store = this.datastore;
       }
+
+
+
 
       opts.message = new HttpErrors.TooManyRequests(
         opts.message?.toString() ?? 'Method rate limit reached !',

--- a/src/providers/ratelimit-action.provider.ts
+++ b/src/providers/ratelimit-action.provider.ts
@@ -6,15 +6,10 @@ import {RateLimitSecurityBindings} from '../keys';
 import {RateLimitAction, RateLimitMetadata, RateLimitOptions} from '../types';
 import {RatelimitDatasourceProvider} from './ratelimit-datasource.provider';
 
-
-
-
-
 export class RatelimitActionProvider implements Provider<RateLimitAction> {
   constructor(
-
     @inject(RateLimitSecurityBindings.DATASOURCEPROVIDER.key)
-    private datastore : RatelimitDatasourceProvider,
+    private datastore: RatelimitDatasourceProvider,
     @inject.getter(RateLimitSecurityBindings.METADATA)
     private readonly getMetadata: Getter<RateLimitMetadata>,
     @inject(CoreBindings.APPLICATION_INSTANCE)
@@ -23,7 +18,6 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
       optional: true,
     })
     private readonly config?: RateLimitOptions,
-
   ) {}
 
   value(): RateLimitAction {
@@ -37,7 +31,6 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
       return Promise.resolve();
     }
 
-
     // Perform rate limiting now
     const promise = new Promise<void>((resolve, reject) => {
       // First check if rate limit options available at method level
@@ -46,13 +39,9 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
       // Create options based on global config and method level config
       const opts = Object.assign({}, this.config, operationMetadata);
 
-
-
       if (this.datastore) {
-      opts.store = this.datastore;
+        opts.store = this.datastore;
       }
-
-
 
       opts.message = new HttpErrors.TooManyRequests(
         opts.message?.toString() ?? 'Method rate limit reached !',

--- a/src/providers/ratelimit-action.provider.ts
+++ b/src/providers/ratelimit-action.provider.ts
@@ -4,12 +4,11 @@ import {Request, Response, RestApplication, HttpErrors} from '@loopback/rest';
 import * as RateLimit from 'express-rate-limit';
 import {RateLimitSecurityBindings} from '../keys';
 import {RateLimitAction, RateLimitMetadata, RateLimitOptions} from '../types';
-import {RatelimitDatasourceProvider} from './ratelimit-datasource.provider';
 
 export class RatelimitActionProvider implements Provider<RateLimitAction> {
   constructor(
-    @inject(RateLimitSecurityBindings.DATASOURCEPROVIDER.key)
-    private datastore: RatelimitDatasourceProvider,
+    @inject(RateLimitSecurityBindings.DATASOURCEPROVIDER)
+    private datastore: RateLimit.Store,
     @inject.getter(RateLimitSecurityBindings.METADATA)
     private readonly getMetadata: Getter<RateLimitMetadata>,
     @inject(CoreBindings.APPLICATION_INSTANCE)
@@ -39,11 +38,8 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
       // Create options based on global config and method level config
       const opts = Object.assign({}, this.config, operationMetadata);
 
-
-
-
       if (this.datastore) {
-      opts.store = this.datastore;
+        opts.store = this.datastore;
       }
 
       opts.message = new HttpErrors.TooManyRequests(

--- a/src/providers/ratelimit-datasource.provider.ts
+++ b/src/providers/ratelimit-datasource.provider.ts
@@ -1,51 +1,44 @@
 import {inject, Provider} from '@loopback/core';
-import {  RateLimitOptions } from '../types'
+import {RateLimitOptions} from '../types';
 import {RateLimitSecurityBindings} from '../keys';
 import {Store} from 'express-rate-limit';
 import RedisStore from 'rate-limit-redis';
 import MemcachedStore from 'rate-limit-memcached';
 import MongoStore from 'rate-limit-mongo';
-type StoreIncrementCallback = (err?: {}, hits?: number, resetTime?: Date) => void;
-export class RatelimitDatasourceProvider implements Provider<Store | undefined>
-{
-
-
+type StoreIncrementCallback = (
+  err?: {},
+  hits?: number,
+  resetTime?: Date,
+) => void;
+export class RatelimitDatasourceProvider
+  implements Provider<Store | undefined> {
   constructor(
-  @inject(RateLimitSecurityBindings.CONFIG, {optional: true,})
-  private readonly config?: RateLimitOptions,
-  ){}
+    @inject(RateLimitSecurityBindings.CONFIG, {optional: true})
+    private readonly config?: RateLimitOptions,
+  ) {}
 
-  value(): Store | undefined
-  {
+  value(): Store | undefined {
+    if (this.config?.type === 'MemcachedStore')
+      return new MemcachedStore({
+        client: this.config?.client,
+        expiration: (this.config?.windowMs ?? 60 * 1000) / 1000,
+      });
 
-    if(this.config?.type ==  'MemcachedStore')
-    return new MemcachedStore({client: this.config?.client, expiration: (this.config?.windowMs ?? 60 * 1000) / 1000} );
+    if (this.config?.type === 'RedisStore')
+      return new RedisStore({
+        client: this.config?.client,
+        expiry: (this.config?.windowMs ?? 60 * 1000) / 1000,
+      });
 
-    if(this.config?.type ==  'RedisStore' )
-    return new RedisStore({client: this.config?.client, expiry: (this.config?.windowMs ?? 60 * 1000) / 1000});
-
-    if(this.config?.type ==  'MongoStore' )
-    return new MongoStore({uri: this.config?.uri, collectionName:this.config?.collectionName ,expireTimeMs: (this.config?.windowMs ?? 60 * 1000) / 1000});
-
+    if (this.config?.type === 'MongoStore')
+      return new MongoStore({
+        uri: this.config?.uri,
+        collectionName: this.config?.collectionName,
+        expireTimeMs: (this.config?.windowMs ?? 60 * 1000) / 1000,
+      });
   }
-  incr(key: string, cb: StoreIncrementCallback)
-  {
-
-  }
-  decrement(key: string)
-  {
-
-  }
-  resetKey(key: string)
-  {
-
-  }
-  resetAll()
-  {
-
-  }
-
-
-
-
+  incr(key: string, cb: StoreIncrementCallback) {}
+  decrement(key: string) {}
+  resetKey(key: string) {}
+  resetAll() {}
 }

--- a/src/providers/ratelimit-datasource.provider.ts
+++ b/src/providers/ratelimit-datasource.provider.ts
@@ -17,7 +17,6 @@ export class RatelimitDatasourceProvider implements Provider<Store | undefined>
 
   value(): Store | undefined
   {
-    console.log(MongoStore);
 
     if(this.config?.type ==  'MemcachedStore')
     return new MemcachedStore({client: this.config?.client, expiration: (this.config?.windowMs ?? 60 * 1000) / 1000} );

--- a/src/providers/ratelimit-datasource.provider.ts
+++ b/src/providers/ratelimit-datasource.provider.ts
@@ -5,7 +5,6 @@ import {Store} from 'express-rate-limit';
 import RedisStore from 'rate-limit-redis';
 import MemcachedStore from 'rate-limit-memcached';
 import MongoStore from 'rate-limit-mongo';
-//import {} from 'rate-limit-mongo'
 type StoreIncrementCallback = (err?: {}, hits?: number, resetTime?: Date) => void;
 export class RatelimitDatasourceProvider implements Provider<Store | undefined>
 {
@@ -14,41 +13,38 @@ export class RatelimitDatasourceProvider implements Provider<Store | undefined>
   constructor(
   @inject(RateLimitSecurityBindings.CONFIG, {optional: true,})
   private readonly config?: RateLimitOptions,
+  ){}
 
-
-  )
-  {
-
-  }
   value(): Store | undefined
   {
+    console.log(MongoStore);
 
     if(this.config?.type ==  'MemcachedStore')
-    return new MemcachedStore({client: this.config?.client, expiration: (this.config?.windowMs ?? 60 * 1000) / 1000});
+    return new MemcachedStore({client: this.config?.client, expiration: (this.config?.windowMs ?? 60 * 1000) / 1000} );
+
     if(this.config?.type ==  'RedisStore' )
-    {
     return new RedisStore({client: this.config?.client, expiry: (this.config?.windowMs ?? 60 * 1000) / 1000});
-    }
+
     if(this.config?.type ==  'MongoStore' )
-    return new MongoStore({client: this.config?.client, expiration: (this.config?.windowMs ?? 60 * 1000) / 1000});
+    return new MongoStore({uri: this.config?.uri, collectionName:this.config?.collectionName ,expireTimeMs: (this.config?.windowMs ?? 60 * 1000) / 1000});
 
   }
-        incr(key: string, cb: StoreIncrementCallback)
-        {
+  incr(key: string, cb: StoreIncrementCallback)
+  {
 
-        }
-        decrement(key: string)
-        {
+  }
+  decrement(key: string)
+  {
 
-        }
-        resetKey(key: string)
-        {
+  }
+  resetKey(key: string)
+  {
 
-        }
-        resetAll()
-        {
+  }
+  resetAll()
+  {
 
-        }
+  }
 
 
 

--- a/src/providers/ratelimit-datasource.provider.ts
+++ b/src/providers/ratelimit-datasource.provider.ts
@@ -5,11 +5,7 @@ import {Store} from 'express-rate-limit';
 import RedisStore from 'rate-limit-redis';
 import MemcachedStore from 'rate-limit-memcached';
 import MongoStore from 'rate-limit-mongo';
-type StoreIncrementCallback = (
-  err?: {},
-  hits?: number,
-  resetTime?: Date,
-) => void;
+
 export class RatelimitDatasourceProvider
   implements Provider<Store | undefined> {
   constructor(
@@ -37,8 +33,4 @@ export class RatelimitDatasourceProvider
         expireTimeMs: (this.config?.windowMs ?? 60 * 1000) / 1000,
       });
   }
-  incr(key: string, cb: StoreIncrementCallback) {}
-  decrement(key: string) {}
-  resetKey(key: string) {}
-  resetAll() {}
 }

--- a/src/providers/ratelimit-datasource.provider.ts
+++ b/src/providers/ratelimit-datasource.provider.ts
@@ -1,0 +1,56 @@
+import {inject, Provider} from '@loopback/core';
+import {  RateLimitOptions } from '../types'
+import {RateLimitSecurityBindings} from '../keys';
+import {Store} from 'express-rate-limit';
+import RedisStore from 'rate-limit-redis';
+import MemcachedStore from 'rate-limit-memcached';
+import MongoStore from 'rate-limit-mongo';
+//import {} from 'rate-limit-mongo'
+type StoreIncrementCallback = (err?: {}, hits?: number, resetTime?: Date) => void;
+export class RatelimitDatasourceProvider implements Provider<Store | undefined>
+{
+
+
+  constructor(
+  @inject(RateLimitSecurityBindings.CONFIG, {optional: true,})
+  private readonly config?: RateLimitOptions,
+
+
+  )
+  {
+
+  }
+  value(): Store | undefined
+  {
+
+    if(this.config?.type ==  'MemcachedStore')
+    return new MemcachedStore({client: this.config?.client, expiration: (this.config?.windowMs ?? 60 * 1000) / 1000});
+    if(this.config?.type ==  'RedisStore' )
+    {
+    return new RedisStore({client: this.config?.client, expiry: (this.config?.windowMs ?? 60 * 1000) / 1000});
+    }
+    if(this.config?.type ==  'MongoStore' )
+    return new MongoStore({client: this.config?.client, expiration: (this.config?.windowMs ?? 60 * 1000) / 1000});
+
+  }
+        incr(key: string, cb: StoreIncrementCallback)
+        {
+
+        }
+        decrement(key: string)
+        {
+
+        }
+        resetKey(key: string)
+        {
+
+        }
+        resetAll()
+        {
+
+        }
+
+
+
+
+}

--- a/src/ratelimitmongo.d.ts
+++ b/src/ratelimitmongo.d.ts
@@ -3,21 +3,26 @@ declare module 'rate-limit-mongo'
 {
   declare namespace MongoStore {
     interface Options {
-        name?:string,
-        expiry?: number;
-        prefix?: string;
-        resetExpiryOnChange?: boolean;
-        client?:  any;
-        redisURL?: string;
+        uri?:string,
+        collectionName?: string,
+        user?: string,
+        password?: string,
+        authSource?: string,
+        collection?: object,
+        connectionOptions?: object,
+        expireTimeMs?: integer,
+        resetExpireDateOnChange?: boolean,
+        errorHandler?: function,
+        createTtlIndex?: boolean
     }
 }
 
 declare class MongoStore implements Store {
-    constructor(options?: RedisStore.Options);
+    constructor(options?: MongoStore.Options);
+    getClient(callback:any):void;
     incr(key: string, cb: StoreIncrementCallback): void;
     decrement(key: string): void;
     resetKey(key: string): void;
-
     resetAll(): void;
 }
 

--- a/src/ratelimitmongo.d.ts
+++ b/src/ratelimitmongo.d.ts
@@ -1,0 +1,25 @@
+
+declare module 'rate-limit-mongo'
+{
+  declare namespace MongoStore {
+    interface Options {
+        name?:string,
+        expiry?: number;
+        prefix?: string;
+        resetExpiryOnChange?: boolean;
+        client?:  any;
+        redisURL?: string;
+    }
+}
+
+declare class MongoStore implements Store {
+    constructor(options?: RedisStore.Options);
+    incr(key: string, cb: StoreIncrementCallback): void;
+    decrement(key: string): void;
+    resetKey(key: string): void;
+
+    resetAll(): void;
+}
+
+export = MongoStore;
+}

--- a/src/ratelimitmongo.d.ts
+++ b/src/ratelimitmongo.d.ts
@@ -1,30 +1,28 @@
-
-declare module 'rate-limit-mongo'
-{
+declare module 'rate-limit-mongo' {
   declare namespace MongoStore {
     interface Options {
-        uri?:string,
-        collectionName?: string,
-        user?: string,
-        password?: string,
-        authSource?: string,
-        collection?: object,
-        connectionOptions?: object,
-        expireTimeMs?: integer,
-        resetExpireDateOnChange?: boolean,
-        errorHandler?: function,
-        createTtlIndex?: boolean
+      uri?: string;
+      collectionName?: string;
+      user?: string;
+      password?: string;
+      authSource?: string;
+      collection?: object;
+      connectionOptions?: object;
+      expireTimeMs?: integer;
+      resetExpireDateOnChange?: boolean;
+      errorHandler?: function;
+      createTtlIndex?: boolean;
     }
-}
+  }
 
-declare class MongoStore implements Store {
+  declare class MongoStore implements Store {
     constructor(options?: MongoStore.Options);
-    getClient(callback:any):void;
+    getClient(callback: string): void;
     incr(key: string, cb: StoreIncrementCallback): void;
     decrement(key: string): void;
     resetKey(key: string): void;
     resetAll(): void;
-}
+  }
 
-export = MongoStore;
+  export = MongoStore;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,11 @@
 import {Request, Response} from '@loopback/rest';
 import {Options} from 'express-rate-limit';
-export const enum DatastoreType { RedisStore = 'RedisStore',
-MemcachedStore = 'MemcachedStore',
-MongoStore = 'MongoStore'
-};
 export interface DataSourceConfig {
   name: string;
   client?: any;
   type?: string;
+  uri?:string,
+  collectionName?:string
 }
 
 export interface RateLimitAction {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,10 +2,10 @@ import {Request, Response} from '@loopback/rest';
 import {Options} from 'express-rate-limit';
 export interface DataSourceConfig {
   name: string;
-  client?: any;
+  client?: string;
   type?: string;
-  uri?:string,
-  collectionName?:string
+  uri?: string;
+  collectionName?: string;
 }
 
 export interface RateLimitAction {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,13 @@
 import {Request, Response} from '@loopback/rest';
 import {Options} from 'express-rate-limit';
-
+export const enum DatastoreType { RedisStore = 'RedisStore',
+MemcachedStore = 'MemcachedStore',
+MongoStore = 'MongoStore'
+};
 export interface DataSourceConfig {
   name: string;
+  client?: any;
+  type?: string;
 }
 
 export interface RateLimitAction {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
-  "experimentalDecorators" : "true"
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "experimentalDecorators" : "true"
 }


### PR DESCRIPTION
Added a provider that will create a new instance of the type of datasource provided by the user. Earlier this rate-limiter was limitted to redis DB only but with the help of the provider the user can use redis, memcache and mongoDB datasource.
Link to the issue resolved:
https://github.com/sourcefuse/loopback4-ratelimiter/issues/4