### PR TITLE
feat(providers): add option to apply ratelimiting over single API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,16 @@ For redis datasource, you have to pass the name of a loopback4 datasource
 ```ts
 this.bind(RateLimitSecurityBindings.CONFIG).to({
   name: 'redis',
-  type:'RedisStore'
+  type: 'RedisStore',
 });
 ```
-
 
 For memcache datasource
 
 ```ts
 this.bind(RateLimitSecurityBindings.CONFIG).to({
   client: memoryClient,
-  type:'MemcachedStore'
+  type: 'MemcachedStore',
 });
 ```
 
@@ -72,6 +71,25 @@ this.bind(RateLimitSecurityBindings.CONFIG).to({
   type: 'RedisStore',
   max: 60,
   keyGenerator: rateLimitKeyGen,
+});
+```
+
+## EnabledbyDefault
+
+enabledByDefault option in Config Binding will provide a configurable mode.
+When its enabled (default value is true),it will provide a way to
+ratelimit all API's except a few that are disabled using a decorator.
+
+To disable ratelimiting for all APIs except those that are enabled using the decorator,
+you can set its value to false in config binding option.
+
+```
+this.bind(RateLimitSecurityBindings.CONFIG).to({
+  name: 'redis',
+  type: 'RedisStore',
+  max: 60,
+  keyGenerator: rateLimitKeyGen,
+  enabledByDefault:false
 });
 ```
 

--- a/src/providers/ratelimit-action.provider.ts
+++ b/src/providers/ratelimit-action.provider.ts
@@ -24,6 +24,7 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
   }
 
   async action(request: Request, response: Response): Promise<void> {
+    const enabledByDefault = this.config?.enabledByDefault ?? true;
     const metadata: RateLimitMetadata = await this.getMetadata();
     const dataStore = await this.getDatastore();
     if (metadata && !metadata.enabled) {
@@ -54,6 +55,12 @@ export class RatelimitActionProvider implements Provider<RateLimitAction> {
         resolve();
       });
     });
-    await promise;
+    if (enabledByDefault === true) {
+      await promise;
+    } else if (enabledByDefault === false && metadata && metadata.enabled) {
+      await promise;
+    } else {
+      return Promise.resolve();
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,12 +15,16 @@ export interface DataSourceConfig {
   uri?: string;
   collectionName?: string;
 }
-
+export interface RateLimitConfig {
+  enabledByDefault?: boolean;
+}
 export interface RateLimitAction {
   (request: Request, response: Response): Promise<void>;
 }
 
-export type RateLimitOptions = Writable<Partial<Options>> & DataSourceConfig;
+export type RateLimitOptions = Writable<Partial<Options>> &
+  DataSourceConfig &
+  RateLimitConfig;
 
 /**
  * Rate limit metadata interface for the method decorator


### PR DESCRIPTION
GH-46

## Description

Added option to apply ratelimiting over single API.

Fixes #46 
GH-46
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
