### PR TITLE
fix(chore): avoid setting config to null always

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -7,12 +7,14 @@ import {
   RateLimitMetadataProvider,
   RatelimitDatasourceProvider,
 } from './providers';
-import {RateLimitMiddlewareConfig} from './types';
+import {RateLimitMiddlewareConfig, RateLimitOptions} from './types';
 
 export class RateLimiterComponent implements Component {
   constructor(
     @inject(RateLimitSecurityBindings.RATELIMITCONFIG, {optional: true})
     private readonly ratelimitConfig?: RateLimitMiddlewareConfig,
+    @inject(RateLimitSecurityBindings.CONFIG, {optional: true})
+    private readonly configOptions?: RateLimitOptions,
   ) {
     this.providers = {
       [RateLimitSecurityBindings.RATELIMIT_SECURITY_ACTION.key]:
@@ -21,9 +23,11 @@ export class RateLimiterComponent implements Component {
         RatelimitDatasourceProvider,
       [RateLimitSecurityBindings.METADATA.key]: RateLimitMetadataProvider,
     };
-    this.bindings.push(
-      Binding.bind(RateLimitSecurityBindings.CONFIG.key).to(null),
-    );
+    if (!this.configOptions) {
+      this.bindings.push(
+        Binding.bind(RateLimitSecurityBindings.CONFIG.key).to(null),
+      );
+    }
     if (this.ratelimitConfig?.RatelimitActionMiddleware) {
       this.bindings.push(createMiddlewareBinding(RatelimitMiddlewareProvider));
     }


### PR DESCRIPTION
## Description

Existing code was unconditionally setting `RateLimitSecurityBindings.CONFIG` to null in the component constructor.
Which is problematic for cases when this config is bound by user before adding the component.
 
This PR removes the need of setting config binding after the component is constructed by adding a condition that checks if the config options are already present.

GH-116

Fixes #116 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
